### PR TITLE
feat: add OpenRouter as LLM provider

### DIFF
--- a/apps/webuiapps/src/components/ChatPanel/index.tsx
+++ b/apps/webuiapps/src/components/ChatPanel/index.tsx
@@ -1290,6 +1290,7 @@ const SettingsModal: React.FC<{
             <option value="minimax">MiniMax</option>
             <option value="z.ai">Z.ai</option>
             <option value="kimi">Kimi</option>
+            <option value="openrouter">OpenRouter</option>
           </select>
         </div>
 

--- a/apps/webuiapps/src/lib/__tests__/llmClient.test.ts
+++ b/apps/webuiapps/src/lib/__tests__/llmClient.test.ts
@@ -135,6 +135,13 @@ describe('getDefaultProviderConfig()', () => {
     expect(cfg.model).toBe('kimi-k2-5');
   });
 
+  it('returns correct defaults for openrouter', () => {
+    const cfg = getDefaultProviderConfig('openrouter');
+    expect(cfg.provider).toBe('openrouter');
+    expect(cfg.baseUrl).toBe('https://openrouter.ai/api/v1');
+    expect(cfg.model).toBe('minimax/MiniMax-M2.5');
+  });
+
   it('returns consistent values for the same provider', () => {
     const a = getDefaultProviderConfig('openai');
     const b = getDefaultProviderConfig('openai');

--- a/apps/webuiapps/src/lib/llmModels.ts
+++ b/apps/webuiapps/src/lib/llmModels.ts
@@ -1,4 +1,11 @@
-export type LLMProvider = 'openai' | 'anthropic' | 'deepseek' | 'minimax' | 'z.ai' | 'kimi';
+export type LLMProvider =
+  | 'openai'
+  | 'anthropic'
+  | 'deepseek'
+  | 'minimax'
+  | 'z.ai'
+  | 'kimi'
+  | 'openrouter';
 
 export type ModelCategory = 'flagship' | 'general' | 'coding' | 'lightweight' | 'thinking';
 
@@ -114,6 +121,23 @@ export const LLM_PROVIDER_CONFIGS: Record<LLMProvider, ProviderModelConfig> = {
       { id: 'kimi-k2', name: 'Kimi K2', category: 'flagship' },
       { id: 'kimi-k2-thinking', name: 'Kimi K2 Thinking', category: 'thinking' },
       { id: 'kimi-k2-turbo', name: 'Kimi K2 Turbo', category: 'general' },
+    ],
+  },
+
+  openrouter: {
+    displayName: 'OpenRouter',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    defaultModel: 'minimax/MiniMax-M2.5',
+    models: [
+      { id: 'minimax/MiniMax-M2.5', name: 'MiniMax M2.5', category: 'flagship' },
+      { id: 'minimax/MiniMax-M2.5-highspeed', name: 'MiniMax M2.5 Highspeed', category: 'general' },
+      { id: 'minimax/MiniMax-M2.7', name: 'MiniMax M2.7', category: 'flagship' },
+      { id: 'minimax/MiniMax-M2.7-highspeed', name: 'MiniMax M2.7 Highspeed', category: 'general' },
+      { id: 'minimax/MiniMax-M2.1', name: 'MiniMax M2.1', category: 'coding' },
+      { id: 'anthropic/claude-sonnet-4-6', name: 'Claude Sonnet 4.6', category: 'general' },
+      { id: 'openai/gpt-5.4', name: 'GPT-5.4', category: 'flagship' },
+      { id: 'deepseek/deepseek-chat', name: 'DeepSeek Chat', category: 'general' },
+      { id: 'google/gemini-2.5-pro', name: 'Gemini 2.5 Pro', category: 'flagship' },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- Add OpenRouter as a new LLM provider, using OpenAI-compatible protocol
- Users can now access MiniMax and other models via OpenRouter's unified API endpoint
- Preset models include MiniMax, Claude, GPT, DeepSeek, Gemini series

Closes #22

## Test plan
- [x] Unit tests pass (`pnpm test` — 107 passed)
- [x] Lint pass (`pnpm run lint`)
- [x] Build pass (`pnpm build`)
- [ ] Manual: select OpenRouter provider, enter API key, send message

🤖 Generated with [Claude Code](https://claude.com/claude-code)