### PR TITLE
feat(llm): upgrade MiniMax default to M3, prune legacy models

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -48,7 +48,7 @@ jobs:
             IMPORTANT: After completing your review, you MUST post your findings as a PR comment.
             Steps to post: 1) Write review to /tmp/review.md using the Write tool, 2) Run: gh pr comment $PR_NUMBER --body-file /tmp/review.md
             Get the PR number first via: gh pr list --state open --json number --jq '.[0].number'
-          claude_args: '--model MiniMax-M2.5 --max-turns 20 --allowedTools "Bash(git:*),Bash(gh:*),Read,Glob,Grep,WebFetch,Write"'
+          claude_args: '--model MiniMax-M3 --max-turns 20 --allowedTools "Bash(git:*),Bash(gh:*),Read,Glob,Grep,WebFetch,Write"'
 
   interactive:
     if: |
@@ -68,4 +68,4 @@ jobs:
           ANTHROPIC_BASE_URL: https://api.minimax.io/anthropic
         with:
           anthropic_api_key: ${{ secrets.MINIMAX_API_KEY }}
-          claude_args: '--model MiniMax-M2.5 --max-turns 20 --allowedTools "Bash(git:*),Bash(gh:*),Read,Glob,Grep,WebFetch,Edit,Write"'
+          claude_args: '--model MiniMax-M3 --max-turns 20 --allowedTools "Bash(git:*),Bash(gh:*),Read,Glob,Grep,WebFetch,Edit,Write"'

--- a/apps/webuiapps/src/lib/__tests__/llmClient.test.ts
+++ b/apps/webuiapps/src/lib/__tests__/llmClient.test.ts
@@ -131,7 +131,7 @@ describe('getDefaultProviderConfig()', () => {
   it('returns correct defaults for minimax', () => {
     const cfg = getDefaultProviderConfig('minimax');
     expect(cfg.provider).toBe('minimax');
-    expect(cfg.baseUrl).toBe('https://api.minimax.io/anthropic/v1');
+    expect(cfg.baseUrl).toBe('https://api.minimax.io/anthropic');
     expect(cfg.model).toBe('MiniMax-M3');
   });
 
@@ -570,6 +570,7 @@ respond_to_user
       expect(result.content).toBe('MiniMax response');
       const headers = mockFetch.mock.calls[0][1].headers as Record<string, string>;
       expect(headers['anthropic-version']).toBe('2023-06-01');
+      expect(headers['X-LLM-Target-URL']).toBe('https://api.minimax.io/anthropic/v1/messages');
     });
   });
 

--- a/apps/webuiapps/src/lib/__tests__/llmClient.test.ts
+++ b/apps/webuiapps/src/lib/__tests__/llmClient.test.ts
@@ -132,7 +132,7 @@ describe('getDefaultProviderConfig()', () => {
     const cfg = getDefaultProviderConfig('minimax');
     expect(cfg.provider).toBe('minimax');
     expect(cfg.baseUrl).toBe('https://api.minimax.io/anthropic/v1');
-    expect(cfg.model).toBe('MiniMax-M2.5');
+    expect(cfg.model).toBe('MiniMax-M3');
   });
 
   it('returns correct defaults for z.ai', () => {
@@ -153,7 +153,7 @@ describe('getDefaultProviderConfig()', () => {
     const cfg = getDefaultProviderConfig('openrouter');
     expect(cfg.provider).toBe('openrouter');
     expect(cfg.baseUrl).toBe('https://openrouter.ai/api/v1');
-    expect(cfg.model).toBe('minimax/MiniMax-M2.5');
+    expect(cfg.model).toBe('minimax/MiniMax-M3');
   });
 
   it('returns consistent values for the same provider', () => {
@@ -560,7 +560,7 @@ respond_to_user
         provider: 'minimax',
         apiKey: 'minimax-key',
         baseUrl: 'https://api.minimax.io/anthropic',
-        model: 'MiniMax-M2.5',
+        model: 'MiniMax-M3',
       };
       const mockFetch = vi.fn().mockResolvedValueOnce(makeAnthropicResponse('MiniMax response'));
       globalThis.fetch = mockFetch;

--- a/apps/webuiapps/src/lib/llmModels.ts
+++ b/apps/webuiapps/src/lib/llmModels.ts
@@ -88,15 +88,11 @@ export const LLM_PROVIDER_CONFIGS: Record<LLMProvider, ProviderModelConfig> = {
   minimax: {
     displayName: 'MiniMax',
     baseUrl: 'https://api.minimax.io/anthropic/v1',
-    defaultModel: 'MiniMax-M2.5',
+    defaultModel: 'MiniMax-M3',
     models: [
-      { id: 'MiniMax-M2.5', name: 'MiniMax M2.5', category: 'flagship' },
-      { id: 'MiniMax-M2.5-highspeed', name: 'MiniMax M2.5 Highspeed', category: 'general' },
-      { id: 'MiniMax-M2.1', name: 'MiniMax M2.1', category: 'coding' },
-      { id: 'MiniMax-M2.1-highspeed', name: 'MiniMax M2.1 Highspeed', category: 'coding' },
+      { id: 'MiniMax-M3', name: 'MiniMax M3', category: 'flagship' },
       { id: 'MiniMax-M2.7', name: 'MiniMax M2.7', category: 'flagship' },
       { id: 'MiniMax-M2.7-highspeed', name: 'MiniMax M2.7 Highspeed', category: 'general' },
-      { id: 'MiniMax-M2', name: 'MiniMax M2', category: 'general' },
     ],
   },
 
@@ -135,13 +131,11 @@ export const LLM_PROVIDER_CONFIGS: Record<LLMProvider, ProviderModelConfig> = {
   openrouter: {
     displayName: 'OpenRouter',
     baseUrl: 'https://openrouter.ai/api/v1',
-    defaultModel: 'minimax/MiniMax-M2.5',
+    defaultModel: 'minimax/MiniMax-M3',
     models: [
-      { id: 'minimax/MiniMax-M2.5', name: 'MiniMax M2.5', category: 'flagship' },
-      { id: 'minimax/MiniMax-M2.5-highspeed', name: 'MiniMax M2.5 Highspeed', category: 'general' },
+      { id: 'minimax/MiniMax-M3', name: 'MiniMax M3', category: 'flagship' },
       { id: 'minimax/MiniMax-M2.7', name: 'MiniMax M2.7', category: 'flagship' },
       { id: 'minimax/MiniMax-M2.7-highspeed', name: 'MiniMax M2.7 Highspeed', category: 'general' },
-      { id: 'minimax/MiniMax-M2.1', name: 'MiniMax M2.1', category: 'coding' },
       { id: 'anthropic/claude-sonnet-4-6', name: 'Claude Sonnet 4.6', category: 'general' },
       { id: 'openai/gpt-5.4', name: 'GPT-5.4', category: 'flagship' },
       { id: 'deepseek/deepseek-chat', name: 'DeepSeek Chat', category: 'general' },

--- a/apps/webuiapps/src/lib/llmModels.ts
+++ b/apps/webuiapps/src/lib/llmModels.ts
@@ -87,7 +87,7 @@ export const LLM_PROVIDER_CONFIGS: Record<LLMProvider, ProviderModelConfig> = {
 
   minimax: {
     displayName: 'MiniMax',
-    baseUrl: 'https://api.minimax.io/anthropic/v1',
+    baseUrl: 'https://api.minimax.io/anthropic',
     defaultModel: 'MiniMax-M3',
     models: [
       { id: 'MiniMax-M3', name: 'MiniMax M3', category: 'flagship' },


### PR DESCRIPTION
## Summary

MiniMax recently released **M3** as the new flagship model. This PR refreshes the bundled MiniMax / OpenRouter provider configurations so OpenRoom ships sensible defaults out of the box.

## Changes

- `apps/webuiapps/src/lib/llmModels.ts`
  - **MiniMax provider**: default model -> `MiniMax-M3`; model list now `M3` (new), `M2.7`, `M2.7-highspeed`. Removed deprecated `M2.5`, `M2.5-highspeed`, `M2.1`, `M2.1-highspeed`, `M2`.
  - **OpenRouter provider**: default model -> `minimax/MiniMax-M3`; MiniMax sub-list now `M3`, `M2.7`, `M2.7-highspeed`. Removed `M2.5`, `M2.5-highspeed`, `M2.1`. Non-MiniMax entries (Claude / GPT / DeepSeek / Gemini) are untouched.
- `apps/webuiapps/src/lib/__tests__/llmClient.test.ts`
  - Updated the two default-model assertions for `minimax` and `openrouter`, and the MiniMax Anthropic-compatible test fixture model id.
- `.github/workflows/claude-review.yml`
  - `claude_args` now uses `--model MiniMax-M3` in both `auto-review` and `interactive` jobs.

The MiniMax Anthropic Base URL is now `https://api.minimax.io/anthropic`; request construction still resolves to `https://api.minimax.io/anthropic/v1/messages`. The provider type and interface code remain unchanged.

## Test plan

- [x] `pnpm test -- --run src/lib/__tests__/llmClient.test.ts` from `apps/webuiapps` -> 47/47 passed (covers the new default for both providers and the MiniMax Anthropic-compatible chat path)
- [x] `pnpm exec eslint apps/webuiapps/src/lib/llmModels.ts apps/webuiapps/src/lib/__tests__/llmClient.test.ts` -> clean
- [x] Manual scan: `rg -i "MiniMax-M2\.5|MiniMax-M2\.1|MiniMax-M[12]\b"` -> no remaining references